### PR TITLE
Fix typo and grammar

### DIFF
--- a/Catalogue/Arithmetic/Löb.lean
+++ b/Catalogue/Arithmetic/Löb.lean
@@ -14,8 +14,7 @@ open LO Entailment FirstOrder Arithmetic Bootstrapping Bootstrapping.Arithmetic
 tag := "löb-theorem"
 %%%
 
-Löb's theorem loughly states that for any sentence `σ`,
-assume "if `σ` is provable, then `σ` is true", then `σ` is true.
+Löb's theorem roughly states that any sentence `σ` is true if the following sentence is true: "if `σ` is provable, then `σ` is true".
 
 {docstring LO.FirstOrder.Arithmetic.löb_theorem}
 


### PR DESCRIPTION
'loughly' → 'roughly'

The statement of Löb's Theorem itself is a bit difficult to phrase nicely, so please check and rephrase as appropriate.